### PR TITLE
Updated definition of Initial Population to return boolean rather tha…

### DIFF
--- a/pages/cql/complete/fhir401/EXM127-9.2.000.cql
+++ b/pages/cql/complete/fhir401/EXM127-9.2.000.cql
@@ -43,9 +43,8 @@ define "SDE Sex":
   SDE."SDE Sex"
 
 define "Initial Population":
-  [Patient] BirthDate
-  	where Global."CalendarAgeInYearsAt"(FHIRHelpers.ToDate(BirthDate.birthDate), start of "Measurement Period")>= 65
-      and exists "Qualifying Encounters"
+  Global."CalendarAgeInYearsAt"(FHIRHelpers.ToDate(Patient.birthDate), start of "Measurement Period")>= 65
+  and exists "Qualifying Encounters"
 
 define "Qualifying Encounters":
        ([Encounter: "Office Visit"]


### PR DESCRIPTION
…n list of patient in EXM127-0.2.000.cql.

We need to change the definition of Initial Population in the CQL to remove the "[Patient] BirthDate" portion of the definition so it returns a boolean instead of a list of patients.